### PR TITLE
ASC-109 Test nova create

### DIFF
--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: https://github.com/rcbops/ansible-role-pytest-rpc
+  version: master

--- a/molecule/default/tests/test_nova_create.py
+++ b/molecule/default/tests/test_nova_create.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+# =============================================================================
+# Imports
+# =============================================================================
+import pytest
+from pytest_rpc.helpers import ping_from_mnaio
+
+
+# =============================================================================
+# Test Cases
+# =============================================================================
+@pytest.mark.test_id('a0b955a3-3ab3-11e9-95a0-6a00035510c0')
+@pytest.mark.jira('ASC-31')
+def test_nova_create(tiny_cirros_server):
+    """Validate the ability to create a nova (compute) resource"""
+
+    assert ping_from_mnaio(tiny_cirros_server.accessIPv4)
+
+    @pytest.mark.testinfra('ansible://' + tiny_cirros_server.accessIPv4)
+    @pytest.mark.test_id('57f87c9e-3adb-11e9-b2ca-6a00035510c0')
+    @pytest.mark.jira('ASC-31')
+    def test_nova_create_connect(host):
+        f = host.file('/etc/hosts')
+        assert f.exists
+        assert f.user == 'root'
+        assert f.group == 'root'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,4 @@
 ---
 # tasks file for molecule-rpco-fsit
+- import_role:
+    name: ansible-role-pytest-rpc


### PR DESCRIPTION
This commit adds a test to create a nova (compute) resource and ensures
that it can be connected to.

This test relies on the previous deployment of openstack api access as
well as network, image, flavor, security groups, and ssh key resources.
Therefore, this commit also includes a converge task pulling in
[ansible-role-pytest-rpc](https://github.com/rcbops/ansible-role-pytest-rpc).
and running the role.